### PR TITLE
feat(e001-s002): /plan routing with Contract-Net scoring and HTTP execution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
-        "@types/jest": "^29.5.14",
+        "@types/jest": "^30.0.0",
         "@types/node": "^24.6.0",
         "@types/supertest": "^6.0.3",
         "@typescript-eslint/eslint-plugin": "^8.45.0",
@@ -2282,197 +2282,14 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "29.5.14",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
-      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "expect": "^29.0.0",
-        "pretty-format": "^29.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/@jest/expect-utils": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
-      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "jest-get-type": "^29.6.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/@jest/types": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/@sinclair/typebox": {
-      "version": "0.27.8",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/jest/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@types/jest/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@types/jest/node_modules/expect": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
-      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/expect-utils": "^29.7.0",
-        "jest-get-type": "^29.6.3",
-        "jest-matcher-utils": "^29.7.0",
-        "jest-message-util": "^29.7.0",
-        "jest-util": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/jest-diff": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
-      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "diff-sequences": "^29.6.3",
-        "jest-get-type": "^29.6.3",
-        "pretty-format": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/jest-matcher-utils": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
-      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "jest-diff": "^29.7.0",
-        "jest-get-type": "^29.6.3",
-        "pretty-format": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/jest-message-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
-      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^29.6.3",
-        "@types/stack-utils": "^2.0.0",
-        "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.9",
-        "micromatch": "^4.0.4",
-        "pretty-format": "^29.7.0",
-        "slash": "^3.0.0",
-        "stack-utils": "^2.0.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/pretty-format": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^18.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "expect": "^30.0.0",
+        "pretty-format": "^30.0.0"
       }
     },
     "node_modules/@types/json-schema": {
@@ -3860,16 +3677,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "node_modules/diff-sequences": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
-      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/dotenv": {
@@ -5450,16 +5257,6 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-get-type": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
-      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-haste-map": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",
-    "@types/jest": "^29.5.14",
+    "@types/jest": "^30.0.0",
     "@types/node": "^24.6.0",
     "@types/supertest": "^6.0.3",
     "@typescript-eslint/eslint-plugin": "^8.45.0",

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,19 +4,25 @@ import swaggerUI from '@fastify/swagger-ui';
 import { toolSchema, registrySchema } from './registry/model';
 import { toolsRoutes } from './routes/tools';
 import { metricsRoutes } from './metrics/metrics';
+import { planRoutes } from './routes/plan';
 import type { IRegistryService } from './registry/service';
+import type { IPlanner } from './planner/contracts';
 
-export function buildApp(deps: { registry: IRegistryService }): FastifyInstance {
+/**
+ * Build the Fastify application with schemas, routes, and Swagger UI.
+ */
+export function buildApp(deps: { registry: IRegistryService; planner: IPlanner }): FastifyInstance {
   const app = Fastify({ logger: true });
 
   app.addSchema({ $id: 'Tool', ...toolSchema });
   app.addSchema({ $id: 'ToolRegistry', ...registrySchema });
 
-  app.register(swagger, { openapi: { info: { title: 'Agentic Orchestrator', version: '0.1.0' } } });
+  app.register(swagger, { openapi: { info: { title: 'Agentic Orchestrator', version: '0.2.0' } } });
   app.register(swaggerUI, { routePrefix: '/docs' });
 
   app.register(async (instance) => {
-    await toolsRoutes(instance, deps);
+    await toolsRoutes(instance, { registry: deps.registry });
+    await planRoutes(instance, { planner: deps.planner });
     await metricsRoutes(instance);
   });
 

--- a/src/executors/httpExecutor.ts
+++ b/src/executors/httpExecutor.ts
@@ -1,0 +1,60 @@
+/**
+ * HTTP Tool Executor using global fetch (Node 20+).
+ * Respects per-tool timeout and overall planner AbortSignal (fallback on timeout).
+ */
+import type { IToolExecutor, ExecutionResult, JsonRecord } from '../planner/contracts';
+import type { Tool } from '../registry/model';
+
+export class HttpExecutor implements IToolExecutor {
+  async execute(tool: Tool, input: JsonRecord, overallAbort: AbortSignal): Promise<ExecutionResult> {
+    if (tool.endpoint?.type !== 'http' || !tool.endpoint.url) {
+      return { status: 'failure', error: 'ENDPOINT_UNSUPPORTED' };
+    }
+
+    const timeoutMs = tool.endpoint.timeout_ms ?? 3000;
+
+    // Per-call timeout layered on top of overallAbort
+    const controller = new AbortController();
+    const timeout = setTimeout((): void => controller.abort('tool-timeout'), timeoutMs);
+
+    const composite = new AbortController();
+    const onOverallAbort = (): void => composite.abort('overall-timeout');
+    overallAbort.addEventListener('abort', onOverallAbort, { once: true });
+
+    // When either aborts, composite aborts (simplified fan-in)
+    controller.signal.addEventListener('abort', (): void => {
+      composite.abort((controller.signal as unknown as { reason?: unknown }).reason);
+    }, { once: true });
+
+    const started = Date.now();
+    try {
+      const res = await fetch(tool.endpoint.url, {
+        method: 'POST', // Use POST for general tool invocation (idempotency can be handled per capability later)
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(input ?? {}),
+        signal: composite.signal
+      });
+
+      const latency_ms = Date.now() - started;
+      clearTimeout(timeout);
+      overallAbort.removeEventListener('abort', onOverallAbort);
+
+      if (!res.ok) {
+        return { status: 'failure', latency_ms, error: `HTTP_${res.status}` };
+      }
+      const output = (await res.json().catch(() => ({}))) as JsonRecord;
+      return { status: 'success', latency_ms, output };
+    } catch (err) {
+      const latency_ms = Date.now() - started;
+      clearTimeout(timeout);
+      overallAbort.removeEventListener('abort', onOverallAbort);
+
+      if ((err as Error).name === 'AbortError') {
+        const reason = String((err as Error & { cause?: unknown }).message ?? 'aborted');
+        const status: ExecutionResult['status'] = reason.includes('overall') ? 'timeout' : 'timeout';
+        return { status, latency_ms, error: reason };
+      }
+      return { status: 'failure', latency_ms, error: (err as Error).message };
+    }
+  }
+}

--- a/src/metrics/metrics.ts
+++ b/src/metrics/metrics.ts
@@ -4,12 +4,52 @@ import client from 'prom-client';
 const register = new client.Registry();
 client.collectDefaultMetrics({ register });
 
+/** Gauge: number of tools currently loaded into the registry. */
 export const toolsLoaded = new client.Gauge({ name: 'tools_loaded', help: 'Number of tools loaded' });
+
+/** Counter: number of registry load/validation errors observed since process start. */
 export const toolLoadErrors = new client.Counter({ name: 'tool_load_errors', help: 'Registry load errors' });
+
+/** Counter: how many scoring bids the planner made per capability/tool. */
+export const plannerBidsTotal = new client.Counter({
+  name: 'planner_bids_total',
+  help: 'Number of planner bids (candidate scores) made',
+  labelNames: ['capability', 'tool'] as const
+});
+
+/** Counter: selections made by the planner per capability/tool. */
+export const plannerSelectionTotal = new client.Counter({
+  name: 'planner_selection_total',
+  help: 'Number of selections made by the planner',
+  labelNames: ['capability', 'tool'] as const
+});
+
+/** Counter: fallbacks performed by the planner per capability. */
+export const plannerFallbacksTotal = new client.Counter({
+  name: 'planner_fallbacks_total',
+  help: 'Number of planner fallbacks after a candidate failure/timeout',
+  labelNames: ['capability'] as const
+});
+
+/** Histogram: time to run the selected tool (can be extended). */
+export const plannerExecutionLatencyMs = new client.Histogram({
+  name: 'planner_execution_latency_ms',
+  help: 'Latency for executing selected tool',
+  buckets: [50, 100, 200, 400, 800, 1600, 3200, 6400],
+  labelNames: ['tool'] as const
+});
 
 register.registerMetric(toolsLoaded);
 register.registerMetric(toolLoadErrors);
+register.registerMetric(plannerBidsTotal);
+register.registerMetric(plannerSelectionTotal);
+register.registerMetric(plannerFallbacksTotal);
+register.registerMetric(plannerExecutionLatencyMs);
 
+/**
+ * Register the Prometheus /metrics endpoint.
+ * @param {FastifyInstance} app - Fastify instance to register the route on.
+ */
 export async function metricsRoutes(app: FastifyInstance): Promise<void> {
   app.get('/metrics', async (_req, reply) => {
     reply.header('Content-Type', register.contentType);

--- a/src/planner/planner.ts
+++ b/src/planner/planner.ts
@@ -1,0 +1,116 @@
+/**
+ * Planner/Router: filters candidates from the registry, scores, selects, executes, and falls back.
+ * Emits metrics and trace events (traceId used now; S003 will expose /trace/:id).
+ */
+import type { IPlanner, PlanContext, PlanResult, IToolExecutor, IScorer, JsonRecord } from './contracts';
+import type { Tool } from '../registry/model';
+import type { IRegistryService } from '../registry/service';
+import { plannerBidsTotal, plannerSelectionTotal, plannerFallbacksTotal } from '../metrics/metrics';
+import { TraceStore } from '../tracing/traceStore';
+
+function supportsCapability(t: Tool, capability: string): boolean {
+  return (t.capabilities ?? []).some(c => c.name === capability);
+}
+
+function preconditionsOk(t: Tool): boolean {
+  const pre = t.preconditions ?? {};
+  if (pre.requiresNetwork && typeof process.env.OFFLINE !== 'undefined') return false;
+  if (pre.env) {
+    for (const k of Object.keys(pre.env)) {
+      if (!process.env[k]) return false;
+    }
+  }
+  return true;
+}
+
+export class Planner implements IPlanner {
+  constructor(
+    private readonly registry: IRegistryService,
+    private readonly scorer: IScorer,
+    private readonly httpExecutor: IToolExecutor,
+    private readonly traces: TraceStore
+  ) {}
+
+  async plan(ctx: PlanContext): Promise<PlanResult> {
+    const execute = ctx.execute !== false; // default true
+    const capability = ctx.capability ?? '';
+    if (!capability) {
+      return { traceId: this.traces.create(), capability: '', candidates: [], execution: { status: 'failure', error: 'INPUT_INVALID' } };
+    }
+
+    const traceId = this.traces.create();
+    this.traces.record(traceId, 'request', ctx);
+
+    // Generate candidates (filter by capability & preconditions)
+    const tools = this.registry.list();
+    const candidates = tools.filter(t => supportsCapability(t, capability) && preconditionsOk(t));
+
+    if (candidates.length === 0) {
+      this.traces.record(traceId, 'no_candidates', { capability });
+      return { traceId, capability, candidates: [], execution: { status: 'failure', error: 'NO_CANDIDATES' } };
+    }
+
+    // Score candidates
+    const input: JsonRecord = ctx.input ?? {};
+    const scored = candidates
+      .map(t => {
+        const score = this.scorer.score(t, { capability, input });
+        plannerBidsTotal.labels({ capability, tool: t.id }).inc();
+        return { toolId: t.id, score, tool: t };
+      })
+      .sort((a, b) => b.score - a.score);
+
+    this.traces.record(traceId, 'scores', scored.map(({ toolId, score }) => ({ toolId, score })));
+
+    const result: PlanResult = {
+      traceId,
+      capability,
+      candidates: scored.map(s => ({ toolId: s.toolId, score: s.score }))
+    };
+
+    if (!execute) {
+      // Decision-only mode
+      const selected = scored[0];
+      if (selected) {
+        result.selected = { toolId: selected.toolId };
+        plannerSelectionTotal.labels({ capability, tool: selected.toolId }).inc();
+      }
+      return result;
+    }
+
+    // Execution with fallback
+    const overallController = new AbortController();
+    if (ctx.timeout_ms && ctx.timeout_ms > 0) {
+      setTimeout(() => overallController.abort('overall-timeout'), ctx.timeout_ms);
+    }
+
+    let rank = 0;
+    for (const cand of scored) {
+      rank++;
+      const tool = cand.tool;
+
+      this.traces.record(traceId, 'attempt', { toolId: tool.id, rank });
+
+      const execRes = await this.httpExecutor.execute(tool, input, overallController.signal);
+
+      if (execRes.status === 'success') {
+        plannerSelectionTotal.labels({ capability, tool: tool.id }).inc();
+        result.selected = { toolId: tool.id };
+        result.execution = execRes;
+        this.traces.record(traceId, 'success', { toolId: tool.id, latency_ms: execRes.latency_ms });
+        return result;
+      }
+
+      // Failed → record + try next candidate
+      plannerFallbacksTotal.labels({ capability }).inc();
+      this.traces.record(traceId, 'fallback', { toolId: tool.id, error: execRes.error, status: execRes.status });
+      // If overall deadline elapsed, break early
+      if (overallController.signal.aborted) break;
+    }
+
+    // No candidate succeeded
+    result.execution = { status: 'failure', error: 'ALL_CANDIDATES_FAILED' };
+    this.traces.record(traceId, 'failure', result.execution);
+    return result;
+  }
+}

--- a/src/routes/plan.ts
+++ b/src/routes/plan.ts
@@ -1,0 +1,69 @@
+/**
+ * /plan endpoint: selects (and optionally executes) the best tool for a capability.
+ * Request body schema is permissive; planner enforces behavior.
+ */
+import type { FastifyInstance, FastifyRequest } from 'fastify';
+import type { IPlanner } from '../planner/contracts';
+import type { PlanContext } from '../planner/contracts';
+
+export async function planRoutes(app: FastifyInstance, deps: { planner: IPlanner }): Promise<void> {
+  app.post(
+    '/plan',
+    {
+      schema: {
+        description: 'Select (and optionally execute) the best tool for a requested capability',
+        body: {
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            capability: { type: 'string' },
+            text: { type: 'string' },
+            input: { type: 'object' },
+            context: { type: 'object' },
+            timeout_ms: { type: 'integer', minimum: 1 },
+            execute: { type: 'boolean' }
+          }
+        },
+        response: {
+          200: {
+            type: 'object',
+            properties: {
+              traceId: { type: 'string' },
+              capability: { type: 'string' },
+              candidates: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    toolId: { type: 'string' },
+                    score: { type: 'number' }
+                  },
+                  required: ['toolId', 'score']
+                }
+              },
+              selected: {
+                type: 'object',
+                properties: { toolId: { type: 'string' } },
+                required: ['toolId']
+              },
+              execution: {
+                type: 'object',
+                properties: {
+                  status: { enum: ['success', 'failure', 'timeout'] },
+                  latency_ms: { type: 'number' },
+                  error: { type: 'string' },
+                  output: { type: 'object' }
+                }
+              }
+            },
+            required: ['traceId', 'capability', 'candidates']
+          }
+        }
+      }
+    },
+    async (req: FastifyRequest<{ Body: PlanContext }>, reply) => {
+      const res = await deps.planner.plan(req.body);
+      return reply.code(200).send(res);
+    }
+  );
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,10 @@ import { loadConfig } from './config/env';
 import { FileRegistryLoader } from './registry/fileRegistryLoader';
 import { RegistryService } from './registry/service';
 import { toolsLoaded, toolLoadErrors } from './metrics/metrics';
+import { SimpleScorer } from './planner/scoring.simple';
+import { Planner } from './planner/planner';
+import { HttpExecutor } from './executors/httpExecutor';
+import { TraceStore } from './tracing/traceStore';
 
 async function main(): Promise<void> {
   const cfg = loadConfig();
@@ -18,8 +22,12 @@ async function main(): Promise<void> {
   }
 
   const registry = new RegistryService(loader);
-  const app = buildApp({ registry });
+  const scorer = new SimpleScorer();
+  const executor = new HttpExecutor();
+  const traces = new TraceStore();
+  const planner = new Planner(registry, scorer, executor, traces);
 
+  const app = buildApp({ registry, planner });
   await app.listen({ port: cfg.port, host: '0.0.0.0' });
 }
 

--- a/src/tracing/traceStore.ts
+++ b/src/tracing/traceStore.ts
@@ -1,0 +1,34 @@
+/**
+ * Minimal trace store to issue IDs now (S002) and attach data in S003.
+ * Using in-memory map; can be swapped for a DB later (DIP).
+ */
+export interface TraceEvent {
+  ts: number;
+  type: string;
+  data: unknown;
+}
+
+export interface Trace {
+  id: string;
+  events: TraceEvent[];
+}
+
+export class TraceStore {
+  private traces = new Map<string, Trace>();
+
+  create(): string {
+    const id = `tr_${Math.random().toString(36).slice(2)}${Date.now().toString(36)}`;
+    this.traces.set(id, { id, events: [] });
+    return id;
+  }
+
+  record(id: string, type: string, data: unknown): void {
+    const t = this.traces.get(id);
+    if (!t) return;
+    t.events.push({ ts: Date.now(), type, data });
+  }
+
+  get(id: string): Trace | undefined {
+    return this.traces.get(id);
+  }
+}

--- a/tests/e2e/plan.e2e.test.ts
+++ b/tests/e2e/plan.e2e.test.ts
@@ -1,0 +1,59 @@
+import request from 'supertest';
+import { buildApp } from '../../src/app';
+import type { IRegistryService } from '../../src/registry/service';
+import type { Tool } from '../../src/registry/model';
+import { Planner } from '../../src/planner/planner';
+import { SimpleScorer } from '../../src/planner/scoring.simple';
+import type { IToolExecutor, ExecutionResult } from '../../src/planner/contracts';
+import { TraceStore } from '../../src/tracing/traceStore';
+
+const tFast: Tool = {
+  id: 'fast', name: 'Fast', version: '1.0.0',
+  capabilities: [{ name: 'patient.search', inputs: {}, outputs: {} }],
+  endpoint: { type: 'http', url: 'http://fast', timeout_ms: 100 },
+  sla: { p95_ms: 200, success_rate_min: 0.99 }, cost_estimate: 0.1
+};
+const tSlow: Tool = {
+  id: 'slow', name: 'Slow', version: '1.0.0',
+  capabilities: [{ name: 'patient.search', inputs: {}, outputs: {} }],
+  endpoint: { type: 'http', url: 'http://slow', timeout_ms: 100 },
+  sla: { p95_ms: 2000, success_rate_min: 0.97 }, cost_estimate: 0.2
+};
+
+class StubExec implements IToolExecutor {
+  async execute(tool: Tool): Promise<ExecutionResult> {
+    // Pretend both succeed; latencies differ by name
+    const latency = tool.id === 'fast' ? 10 : 50;
+    return { status: 'success', latency_ms: latency, output: { id: tool.id } };
+  }
+}
+
+describe('/plan e2e', () => {
+  let app: ReturnType<typeof buildApp>;
+
+  beforeAll(async () => {
+    const registry: IRegistryService = {
+      list: () => [tFast, tSlow],
+      getRegistry: () => ({ tools: [tFast, tSlow], updatedAt: new Date().toISOString() })
+    };
+    const planner = new Planner(registry, new SimpleScorer(), new StubExec(), new TraceStore());
+    app = buildApp({ registry, planner });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('selects and executes the best candidate', async () => {
+    const res = await request(app.server)
+      .post('/plan')
+      .send({ capability: 'patient.search', input: { mrn: '123' }, execute: true });
+
+    expect(res.status).toBe(200);
+    expect(res.body.capability).toBe('patient.search');
+    expect(res.body.candidates.length).toBe(2);
+    expect(res.body.selected.toolId).toBe('fast');
+    expect(res.body.execution.status).toBe('success');
+  });
+});

--- a/tests/unit/planner.fallback.test.ts
+++ b/tests/unit/planner.fallback.test.ts
@@ -1,0 +1,45 @@
+import { Planner } from '../../src/planner/planner';
+import { SimpleScorer } from '../../src/planner/scoring.simple';
+import type { IRegistryService } from '../../src/registry/service';
+import type { Tool } from '../../src/registry/model';
+import type { IToolExecutor, ExecutionResult } from '../../src/planner/contracts';
+import { TraceStore } from '../../src/tracing/traceStore';
+
+const t1: Tool = {
+  id: 't1', name: 'T1', version: '1.0.0',
+  capabilities: [{ name: 'patient.search', inputs: {}, outputs: {} }],
+  endpoint: { type: 'http', url: 'http://tool-1', timeout_ms: 100 },
+  sla: { p95_ms: 400, success_rate_min: 0.98 }, cost_estimate: 0.2
+};
+
+const t2: Tool = {
+  id: 't2', name: 'T2', version: '1.0.0',
+  capabilities: [{ name: 'patient.search', inputs: {}, outputs: {} }],
+  endpoint: { type: 'http', url: 'http://tool-2', timeout_ms: 100 },
+  sla: { p95_ms: 500, success_rate_min: 0.97 }, cost_estimate: 0.1
+};
+
+class FailingExec implements IToolExecutor {
+  // fail once, then succeed
+  private count = 0;
+  async execute(): Promise<ExecutionResult> {
+    this.count++;
+    if (this.count === 1) return { status: 'timeout', error: 'timeout' };
+    return { status: 'success', latency_ms: 12, output: { ok: true } };
+  }
+}
+
+describe('Planner fallback', () => {
+  it('falls back when the top candidate fails', async () => {
+    const registry: IRegistryService = { list: () => [t1, t2], getRegistry: () => ({ tools: [t1, t2], updatedAt: new Date().toISOString() }) };
+    const scorer = new SimpleScorer();
+    const exec = new FailingExec();
+    const traces = new TraceStore();
+
+    const planner = new Planner(registry, scorer, exec, traces);
+
+    const res = await planner.plan({ capability: 'patient.search', input: {}, execute: true, timeout_ms: 500 });
+    expect(res.execution?.status).toBe('success');
+    expect(res.selected?.toolId).toBeDefined();
+  });
+});


### PR DESCRIPTION
Implements candidate filtering, scoring, selection, fallback, and execution via HTTP. Adds /plan route, planner metrics, and e2e tests. Swagger updated via route schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced planning capability with a POST /plan endpoint to score, select, and optionally execute tools with timeouts; returns candidates, selection, and execution details.
  * Added HTTP-based tool execution with robust timeout and error handling.
  * Added tracing identifiers for plan executions.
* **Metrics**
  * Exposed /metrics with Prometheus metrics for tools loaded, planner bids, selections, fallbacks, and execution latency.
* **Documentation**
  * Updated API documentation version to 0.2.0.
* **Tests**
  * Added end-to-end and unit tests for planning and fallback behavior.
* **Chores**
  * Updated Jest type definitions (dev dependency).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->