### PR TITLE
chore(repo): harden .gitignore and add .dockerignore for lean builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.gitignore
+node_modules
+dist
+coverage
+Dockerfile
+docker-compose*.yml
+.vscode
+.idea
+*.log
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,73 @@
-node_modules
-dist
+# ========= Node / Package Managers =========
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+package-lock.json
+# (Keep package-lock.json if you want reproducible installs. Remove this line then.)
+
+# ========= Build Artifacts =========
+dist/
+coverage/
+.build/
+.tmp/
+.cache/
+.esbuild/
+tsconfig.tsbuildinfo
+
+# ========= TypeScript / Testing =========
+*.tsbuildinfo
+.jest-cache/
+.jest/
+.vitest/
+*.tap
+.tap/
+
+# ========= Env & Secrets =========
 .env
+.env.*
+!.env.example
+
+# ========= Logs =========
+logs/
+*.log
+*.log.*
+*.out
+*.err
+pino*.log
+
+# ========= Editors / OS =========
 .DS_Store
-coverage
+Thumbs.db
+.idea/
+.vscode/*
+!.vscode/extensions.json
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+
+# ========= Tooling / Lint / Formatting =========
+.prettier-cache
+eslintcache
+/.eslintcache
+
+# ========= Runtime / Local Dev =========
+*.pid
+*.pid.lock
+*.seed
+*.swp
+*.swo
+
+# ========= Docker / Containers =========
+docker-compose.override.yml
+.docker/
+*.local.yml
+
+# ========= Swagger / OpenAPI generated (if you export later) =========
+openapi.json
+openapi.yaml
+
+# ========= Registry: keep source YAML/JSON, ignore derived artifacts =========
+registry/**/*.generated.*
+registry/**/*.cache.*


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced a .dockerignore to exclude common folders/files from Docker build context, improving build efficiency.
  * Expanded and reorganized .gitignore into clear sections covering tooling logs, package locks, build and test outputs, environment files, editor/OS artifacts, Docker files, and API spec caches.
  * Reduces repository noise, prevents accidental commits of sensitive or generated files, and streamlines local development and CI builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->